### PR TITLE
Use Markdown format for the license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2017 GodotNativeTools
 


### PR DESCRIPTION
This makes it display as Markdown on GitHub, which is more readable than plain text display :slightly_smiling_face: