### PR TITLE
Remove question about NativeScripts being in Godot 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,6 @@ use of GDNative to implement scripts backed by native code.
 You must compile the library with debug
 symbols, and then you can use your debugger as usual.
 
-**Are NativeScripts in Godot 3.0?**
-
-They are! 🎉
-
 **Can you use one GDNativeLibrary for all NativeScripts?**
 
 You can! ✨


### PR DESCRIPTION
Godot 3.0 has been out for a while, no need to include it in the FAQ anymore :slightly_smiling_face:

This PR could also be cherry-picked into the `3.1` branch.